### PR TITLE
fix(P81-122155): use /v2 module path for v2+ semantic import versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Perimeter81-Public/perimeter-81-client-sdk
+module github.com/Perimeter81-Public/perimeter-81-client-sdk/v2
 
 go 1.26.2
 

--- a/test/api_application_test.go
+++ b/test/api_application_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_ApplicationAPIService(t *testing.T) {

--- a/test/api_enhanced_networks_test.go
+++ b/test/api_enhanced_networks_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_EnhancedNetworksAPIService(t *testing.T) {

--- a/test/api_enhanced_regions_test.go
+++ b/test/api_enhanced_regions_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_EnhancedRegionsAPIService(t *testing.T) {

--- a/test/api_enhanced_route_tables_test.go
+++ b/test/api_enhanced_route_tables_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_EnhancedRouteTablesAPIService(t *testing.T) {

--- a/test/api_enhanced_tunnels_test.go
+++ b/test/api_enhanced_tunnels_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_EnhancedTunnelsAPIService(t *testing.T) {

--- a/test/api_firewall_policy_test.go
+++ b/test/api_firewall_policy_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_FirewallPolicyAPIService(t *testing.T) {

--- a/test/api_gateways_test.go
+++ b/test/api_gateways_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_GatewaysAPIService(t *testing.T) {

--- a/test/api_ip_sec_redundant_test.go
+++ b/test/api_ip_sec_redundant_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_IPSecRedundantAPIService(t *testing.T) {

--- a/test/api_ip_sec_single_test.go
+++ b/test/api_ip_sec_single_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_IPSecSingleAPIService(t *testing.T) {

--- a/test/api_networks_test.go
+++ b/test/api_networks_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_NetworksAPIService(t *testing.T) {

--- a/test/api_objects_addresses_test.go
+++ b/test/api_objects_addresses_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_ObjectsAddressesAPIService(t *testing.T) {

--- a/test/api_objects_services_test.go
+++ b/test/api_objects_services_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_ObjectsServicesAPIService(t *testing.T) {

--- a/test/api_open_vpn_test.go
+++ b/test/api_open_vpn_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_OpenVPNAPIService(t *testing.T) {

--- a/test/api_regions_test.go
+++ b/test/api_regions_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_RegionsAPIService(t *testing.T) {

--- a/test/api_route_table_test.go
+++ b/test/api_route_table_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_RouteTableAPIService(t *testing.T) {

--- a/test/api_standard_networks_test.go
+++ b/test/api_standard_networks_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_StandardNetworksAPIService(t *testing.T) {

--- a/test/api_wireguard_test.go
+++ b/test/api_wireguard_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
-	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk"
+	openapiclient "github.com/Perimeter81-Public/perimeter-81-client-sdk/v2"
 )
 
 func Test_perimeter81sdk_WireguardAPIService(t *testing.T) {


### PR DESCRIPTION
## Summary

- Rename Go module path from `github.com/Perimeter81-Public/perimeter-81-client-sdk` to `.../v2` so v2+ tags (e.g. `v2.3.0`) are consumable via plain `go get` / `require`.
- Update self-imports in `test/` to match the new module path.

## Why

Under Go's Semantic Import Versioning, any v2+ tag of a module that has a `go.mod` file MUST declare its module path with a `/v2` suffix. The current `v2.3.0` tag is unusable by consumers:

- `require ... v2.3.0` → rejected (`module path must match major version "v2"`)
- `require ... v2.3.0+incompatible` → rejected (`+incompatible suffix not allowed: module contains a go.mod file`)

Today the terraform-provider-perimeter81 has to work around this with a local `replace` directive. With this fix and a re-tagged `v2.3.x`, the provider can consume the SDK directly from the remote tag.

## Follow-up

- After merge, retag (Oleksandr will recreate the tag as `v2.3.x`).
- Then the provider (P81-115711) will rewrite imports to `.../v2` and drop the `replace`.

## Jira

- [P81-122155](https://perimeter81.atlassian.net/browse/P81-122155) — fix Go module path for v2+ SIV
- Parent: [P81-115249](https://perimeter81.atlassian.net/browse/P81-115249)

## Test plan

- [ ] `go mod tidy` succeeds with the new module path
- [ ] `go build ./...` clean
- [ ] After re-tag, provider can consume the SDK without `replace` / `+incompatible`